### PR TITLE
Add legal disclaimer and repository policies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sofian Belloul
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ minimaliste au framework macOS **SidecarCore** afin de désactiver la vérificat
 compatibilité côté appareil. Le projet a été nettoyé pour ne contenir que le code
 nécessaire au patch, sans binaires compilés ni artefacts temporaires.
 
+> ⚠️ **Avertissement légal**
+>
+> Ce projet est fourni uniquement à des fins éducatives et expérimentales.
+> Il ne contient aucun fichier propriétaire d’Apple.
+> L'utilisation de ce script pour modifier un composant de macOS peut enfreindre la
+> licence d'utilisation d'Apple ou des lois locales (ex. DMCA §1201).
+> Vous êtes seul responsable de l'usage que vous en faites.
+
 ## Fonctionnalités
 
 - Recherche automatique de la signature machine de la fonction

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security & Legal Contact
+
+If you believe that this project infringes on your rights or violates a security
+policy, please open an issue with the prefix `[SECURITY]` or contact:
+📧 sofian.bll@proton.me
+
+This repository contains only research and educational code.
+No proprietary Apple binaries are distributed.


### PR DESCRIPTION
## Summary
- add MIT license file to clarify reuse terms
- document legal disclaimer in the README warning users about potential DMCA/EULA issues
- introduce SECURITY.md with contact details for takedown or security reports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24c48fef483229095bf3e321716a2